### PR TITLE
Allow absolute override of the included template

### DIFF
--- a/definitions/nginx_api_proxy.rb
+++ b/definitions/nginx_api_proxy.rb
@@ -1,9 +1,15 @@
-define :nginx_api_proxy, name: nil, domain: nil, forwared_for: nil, enable: true do
+define :nginx_api_proxy, enable: true, name: nil, domain: nil, forwared_for: nil, source: 'proxied-api.conf.erb', cookbook: 'apiaxle' do
   template "#{node[:nginx][:dir]}/sites-available/#{params[:name]}" do
-    source 'proxied-api.conf.erb'
+    source   params[:source]
+    cookbook params[:cookbook]
     notifies :reload, 'service[nginx]'
-    variables api_name: params[:name], domain: params[:domain], forwarded_for: params[:forwarded_for]
+    variables(
+      domain:        params[:domain],
+      api_name:      params[:name],
+      forwarded_for: params[:forwarded_for]
+    )
   end
+
   if params[:enable]
     nginx_site params[:name]
   else


### PR DESCRIPTION
allow user-defined shenanigans to take place:
- for example, if a user would like the proxy to perform certain
  redirects or rewrites of traffic entering their service, they can include their own template in the cookbook of their choosing and point to it in the definition by specifying the source and cookbook parameters
